### PR TITLE
Set AWS_SDK_LOAD_CONFIG flag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ runs:
   steps: 
     - run: |
         FILE_NAME=${AWS_SHARED_CREDENTIALS_FILE:-$RUNNER_TEMP/.aws/credentials}
+        echo "AWS_SDK_LOAD_CONFIG=true" >> $GITHUB_ENV # Needed for the JS AWS SDK to use AWS_SHARED_CREDENTIALS_FILE
         echo "AWS_SHARED_CREDENTIALS_FILE=$FILE_NAME" >> $GITHUB_ENV
         mkdir -p "$(dirname "$FILE_NAME")"
         echo "[${{ inputs.profile-name }}]" >> $FILE_NAME


### PR DESCRIPTION
[LURV-1556](https://desire2learn.atlassian.net/browse/LURV-1556)

This PR sets the AWS_SDK_LOAD_CONFIG flag which is required in the AWS SDK for JS to use the AWS_SHARED_CREDENTIALS_FILE env variable instead of the default path for AWS credentials.

[LURV-1556]: https://desire2learn.atlassian.net/browse/LURV-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ